### PR TITLE
fix cairo revision confirmed with integration test CI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -106,7 +106,11 @@ enum Commands {
         cairo_input: Option<String>,
     },
     /// Return the compiled cairo file that works with integration test
-    CompiledCairo { output_path: String },
+    CompiledCairo {
+        /// Path to save the compiled cairo json file
+        #[arg(short, long)]
+        output_path: String,
+    },
 }
 
 #[derive(Subcommand, Clone, Debug, PartialEq, Eq)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -105,6 +105,8 @@ enum Commands {
         #[arg(short, long)]
         cairo_input: Option<String>,
     },
+    /// Return the compiled cairo file that works with integration test
+    CompiledCairo { output_path: String },
 }
 
 #[derive(Subcommand, Clone, Debug, PartialEq, Eq)]
@@ -561,6 +563,11 @@ async fn main() -> Result<()> {
                 cairo_input,
             )
             .await?
+        }
+        Commands::CompiledCairo { output_path } => {
+            // save the compiled cairo file to the output path
+            let compiled_cairo = include_str!("../../compiled_cairo/hdp.json");
+            std::fs::write(output_path, compiled_cairo)?;
         }
     }
     let duration_run = start_run.elapsed();


### PR DESCRIPTION
this repository will expose script to recompile cairo program in certain revision. And as the integration test works with basic `hdp.json`, we have a flow to check new feature ( new input ) generated by cli tool is indeed compatible with specific revision of cairo program that we represent as compiled_cairo. 

So that, for solidity contract and both server doesn't need to care about cairo revision, so don't need to consider about recompile. 

Again, responsibilty of recompile and both fixing working revision of specific features are all take care by this rust program. 