### PR TITLE
better fetcher

### DIFF
--- a/crates/core/src/compiler/block_sampled.rs
+++ b/crates/core/src/compiler/block_sampled.rs
@@ -80,9 +80,8 @@ pub async fn compile_block_sampled_datalake(
 
             for block in block_range {
                 let fetched_block = full_header_and_proof_result.0.get(&block).unwrap().clone();
-                let acc = accounts_and_proofs_result.get(&block).unwrap().clone();
-                // encoded_account = acc.0.clone();
-                let value = property.decode_field_from_rlp(&acc.0);
+                let account_proof = accounts_and_proofs_result.get(&block).unwrap().clone();
+                let value = property.decode_field_from_rlp(&account_proof.encoded_account);
 
                 headers.push(Header {
                     rlp: fetched_block.0,
@@ -94,7 +93,7 @@ pub async fn compile_block_sampled_datalake(
 
                 let account_proof = MPTProof {
                     block_number: block,
-                    proof: acc.1,
+                    proof: account_proof.account_proof,
                 };
 
                 account_proofs.push(account_proof);
@@ -124,7 +123,7 @@ pub async fn compile_block_sampled_datalake(
 
             for i in block_range {
                 let fetched_block = full_header_and_proof_result.0.get(&i).unwrap().clone();
-                let acc_and_storage = storages_and_proofs_result.get(&i).unwrap().clone();
+                let storage_proof = storages_and_proofs_result.get(&i).unwrap().clone();
 
                 headers.push(Header {
                     rlp: fetched_block.0,
@@ -136,15 +135,15 @@ pub async fn compile_block_sampled_datalake(
 
                 account_proofs.push(MPTProof {
                     block_number: i,
-                    proof: acc_and_storage.1,
+                    proof: storage_proof.account_proof,
                 });
 
                 storage_proofs.push(MPTProof {
                     block_number: i,
-                    proof: acc_and_storage.3,
+                    proof: storage_proof.storage_proof,
                 });
 
-                aggregation_set.push(acc_and_storage.2);
+                aggregation_set.push(storage_proof.storage_value);
             }
 
             let storage_key = keccak256(slot).to_string();

--- a/crates/provider/src/evm/mod.rs
+++ b/crates/provider/src/evm/mod.rs
@@ -1,16 +1,11 @@
 use alloy_primitives::Bytes;
-use anyhow::{bail, Result};
-use core::panic;
+use anyhow::Result;
 use eth_trie_proofs::{tx_receipt_trie::TxReceiptsMptHandler, tx_trie::TxsMptHandler};
-use futures::future::join_all;
-use std::{collections::HashMap, sync::Arc, time::Instant};
-use tokio::sync::{mpsc, RwLock};
+use std::{collections::HashMap, time::Instant};
+use tokio::sync::mpsc;
 use tracing::{error, info};
 
-use hdp_primitives::{
-    block::{account::Account, header::Header},
-    datalake::output::MMRMeta,
-};
+use hdp_primitives::{block::header::Header, datalake::output::MMRMeta};
 
 use self::{
     memory::{InMemoryProvider, RlpEncodedValue, StoredHeader, StoredHeaders},
@@ -231,33 +226,6 @@ impl AbstractProvider {
         }
     }
 
-    // pub async fn get_account_with_proof(
-    //     &mut self,
-    //     block_number: u64,
-    //     account: &str,
-    // ) -> (String, Vec<String>) {
-    //     match self.memory.get_account(block_number, account) {
-    //         Some(account_with_proof) => account_with_proof,
-    //         None => {
-    //             let account_rpc = self
-    //                 .account_provider
-    //                 .get_proof(block_number, account, None)
-    //                 .await
-    //                 .unwrap();
-    //             let retrieved_account = Account::from(&account_rpc);
-    //             let rlp_encoded = retrieved_account.rlp_encode();
-    //             let account_proof = account_rpc.account_proof;
-    //             self.memory.set_account(
-    //                 block_number,
-    //                 account_rpc.address,
-    //                 rlp_encoded.clone(),
-    //                 account_proof.clone(),
-    //             );
-    //             (rlp_encoded, account_proof)
-    //         }
-    //     }
-    // }
-
     // Get account with proof in given range of blocks
     // This need to be used for block sampled datalake
     pub async fn get_range_account_with_proof(
@@ -269,7 +237,6 @@ impl AbstractProvider {
     ) -> Result<HashMap<u64, (String, Vec<String>)>> {
         type AccountWithProof = (u64, String, Vec<String>);
         let start_fetch = Instant::now();
-        //? A map of block numbers to a boolean indicating whether the block was fetched.
 
         let target_block_range: Vec<u64> = (block_range_start..=block_range_end)
             .step_by(increment as usize)
@@ -293,42 +260,6 @@ impl AbstractProvider {
         Ok(result)
     }
 
-    // pub async fn get_storage_value_with_proof(
-    //     &mut self,
-    //     block_number: u64,
-    //     account: String,
-    //     slot: String,
-    // ) -> Result<(String, Vec<String>)> {
-    //     match self
-    //         .memory
-    //         .get_storage(block_number, account.clone(), slot.clone())
-    //     {
-    //         Some(storage) => Ok(storage),
-    //         None => {
-    //             let account_rpc = self
-    //                 .account_provider
-    //                 .get_proof(block_number, &account, Some(vec![slot.clone()]))
-    //                 .await?;
-    //             let retrieved_account = Account::from(&account_rpc);
-    //             let rlp_encoded = retrieved_account.rlp_encode();
-    //             let storage = &account_rpc.storage_proof[0];
-    //             let storage_slot = storage.key.clone();
-    //             let storage_value = storage.value.clone();
-    //             let storage_proof = account_rpc.storage_proof[0].proof.clone();
-    //             self.memory.set_storage(
-    //                 block_number,
-    //                 account.clone(),
-    //                 rlp_encoded,
-    //                 account_rpc.account_proof,
-    //                 storage_slot,
-    //                 storage_value.clone(),
-    //                 storage_proof.clone(),
-    //             );
-    //             Ok((storage_value, storage_proof))
-    //         }
-    //     }
-    // }
-
     // Get storage with proof in given range of blocks
     // This need to be used for block sampled datalake
     pub async fn get_range_storage_with_proof(
@@ -339,127 +270,33 @@ impl AbstractProvider {
         address: String,
         slot: String,
     ) -> Result<HashMap<u64, (String, Vec<String>, String, Vec<String>)>> {
+        type StorageWithProof = (u64, String, Vec<String>, String, Vec<String>);
         let start_fetch = Instant::now();
         //? A map of block numbers to a boolean indicating whether the block was fetched.
-        // This contains rlp encoded account, account proof, storage value and storage proof
-        let blocks_map = Arc::new(RwLock::new(HashMap::new()));
-
         let target_block_range: Vec<u64> = (block_range_start..=block_range_end)
             .step_by(increment as usize)
             .collect();
 
-        for block_number in &target_block_range {
-            let storage = self
-                .memory
-                .get_storage(*block_number, address.clone(), slot.clone());
-            let account = self.memory.get_account(*block_number, &address);
-            if let Some(storage) = storage {
-                let retrieved_account = account.unwrap();
-                let mut blocks_map_write = blocks_map.write().await;
-                blocks_map_write.insert(
-                    *block_number,
-                    (
-                        true,
-                        retrieved_account.0,
-                        retrieved_account.1,
-                        storage.0,
-                        storage.1,
-                    ),
-                );
-            }
-        }
-
-        // chunk the target_block_range into 40
-        let target_block_range_chunks: Vec<Vec<u64>> =
-            target_block_range.chunks(40).map(|x| x.to_vec()).collect();
-
-        for one_chunk_block_range in target_block_range_chunks {
-            // Prepare and execute futures for missing blocks
-            let fetch_futures: Vec<_> = one_chunk_block_range
-                .clone()
-                .into_iter()
-                .map(|block_number| {
-                    let blocks_map_clone = blocks_map.clone();
-                    let rpc_clone = self.rpc_provider.clone(); // Assume self.rpc can be cloned or is wrapped in Arc
-                    let address_clone = address.clone();
-                    let slot_clone = slot.clone();
-                    async move {
-                        let should_fetch = {
-                            let read_guard = blocks_map_clone.read().await;
-                            !read_guard.contains_key(&block_number)
-                        };
-                        if should_fetch {
-                            match rpc_clone
-                                .get_proof(block_number, &address_clone, Some(vec![slot_clone]))
-                                .await
-                            {
-                                Ok(account_from_rpc) => {
-                                    let mut write_guard = blocks_map_clone.write().await;
-                                    let retrieved_account = Account::from(&account_from_rpc);
-                                    let storage = &account_from_rpc.storage_proof[0];
-                                    let rlp_encoded = retrieved_account.rlp_encode();
-                                    let storage_value = storage.value.clone();
-                                    let storage_proof =
-                                        account_from_rpc.storage_proof[0].proof.clone();
-                                    let account_proof = account_from_rpc.account_proof;
-                                    write_guard.insert(
-                                        block_number,
-                                        (
-                                            true,
-                                            rlp_encoded,
-                                            account_proof,
-                                            storage_value,
-                                            storage_proof,
-                                        ),
-                                    );
-                                    // Assuming conversion to RlpEncodedValue is done here
-                                }
-                                Err(e) => {
-                                    // TODO: handle error in proper way
-                                    if e.to_string().contains("No storage proof found") {
-                                        error!("Storage value not exist: {}", e);
-                                        panic!("{}", e);
-                                    } else {
-                                        error!(
-                                            "Failed to fetch storage in block {}: {}",
-                                            block_number, e
-                                        );
-                                        bail!(e);
-                                    }
-                                }
-                            }
-                        }
-                        Ok(())
-                    }
-                })
-                .collect();
-
-            // Execute fetch operations in parallel
-            join_all(fetch_futures).await;
-
-            // wait for 0.1s
-            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-        }
-
-        // Construct the final result vector from blocks_map
-        let blocks_map_read = blocks_map.read().await;
-        let duration = start_fetch.elapsed();
-        info!("Time taken (Storage Fetch): {:?}", duration);
+        let (rpc_sender, mut rx) = mpsc::channel::<StorageWithProof>(32);
+        self.rpc_provider
+            .get_storage_proofs(rpc_sender, target_block_range, &address, slot)
+            .await;
 
         let mut result = HashMap::new();
 
-        for block in &target_block_range {
-            if !blocks_map_read.contains_key(block) {
-                bail!("Failed to fetch storage in block {}", block);
-            }
+        while let Some(block) = rx.recv().await {
             result.insert(
-                *block,
-                blocks_map_read
-                    .get(block)
-                    .map(|(_, a, b, c, d)| (a.clone(), b.clone(), c.clone(), d.clone()))
-                    .unwrap(),
+                block.0,
+                (
+                    block.1.clone(),
+                    block.2.clone(),
+                    block.3.clone(),
+                    block.4.clone(),
+                ),
             );
         }
+        let duration = start_fetch.elapsed();
+        info!("Time taken (Storage Fetch): {:?}", duration);
 
         Ok(result)
     }

--- a/crates/provider/src/evm/rpc.rs
+++ b/crates/provider/src/evm/rpc.rs
@@ -139,11 +139,11 @@ impl RpcProvider {
                                     rpc_sender.send(mpt_proof).await.unwrap();
                                     blocks_identifier.insert(*block_number);
                                 }
-                                Err(e) => {
-                                    println!(
-                                        "Failed to fetch block number: {}, error: {}",
-                                        block_number, e
-                                    );
+                                Err(_) => {
+                                    // println!(
+                                    //     "Failed to fetch block number: {}, error: {}",
+                                    //     block_number, e
+                                    // );
                                 }
                             }
                         }


### PR DESCRIPTION
### Some numbers

`Account`
- 1100
```bash
cargo run -- encode -a -o output.json -c input.json "slr" -b 4952200 4953300 "account.0x7f2c6f930306d3aa736b3a6c6a98f512f74036d4.balance" 1
```

```sh
hdp_provider::evm: Time taken (fetch from Indexer): 16.756281333s
hdp_provider::evm: Time taken (Account Fetch): 40.069458167s
hdp: HDP Cli Finished in: 57.397152583s
```
- 1500
```bash
 cargo run -- encode -a -o output.json -c input.json "slr" -b 4952200 4953700 "account.0x7f2c6f930306d3aa736b3a6c6a98f512f74036d4.balance" 1
```

```sh
Time taken (fetch from Indexer): 8.510314125s
 Time taken (Account Fetch): 54.080993208s
HDP Cli Finished in: 63.3760285s
```

`Storage`
```sh
 cargo run -- encode -a -o output.json -c input.json "slr" -b 5382769 5383769 "storage.0x75cec1db9dceb703200eaa6595f66885c962b920.0x0000000000000000000000000000000000000000000000000000000000000002" 1
```
Successfully fetched MMR data from indexer
Time taken (fetch from Indexer): 9.04892825s
Time taken (Storage Fetch): 36.797151s
HDP Cli Finished in: 46.425361917s
```